### PR TITLE
Update redis-py version to fix connection error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ kombu==4.3.0
 MarkupSafe==1.1.0
 python-mimeparse==1.6.0
 pytz==2018.9
-redis==3.1.0
+redis==3.5.3
 requests==2.21.0
 six==1.12.0
 urllib3==1.24.1


### PR DESCRIPTION
When the redis server the client's connection is connected to is restarted,
the connection will throw ConnectionError when used. This fix attempts to
fix this issue by updating the client to a newer version which will try to
reconnect if a connection is no longer connected.